### PR TITLE
Increase default proxy buffer size for nginx

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -28,6 +28,8 @@ http {
     client_header_timeout 5s;
     client_body_timeout 20s;
     send_timeout 20s;
+    
+    proxy_buffer_size 8k;
 
     log_format main '$remote_addr - $remote_user [$time_local]  '
                     '"$request" $status $body_bytes_sent '


### PR DESCRIPTION
The default when not specific is 4k. Since we're serving quite a bit more CSP headers these days, our header weighs in at about 4.3k. This should keep us covered for awhile.