### PR TITLE
Pass real IP's to nginx logs

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -14,8 +14,29 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    # set real ip from X-Forwarded-For header
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 104.16.0.0/12;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2c0f:f248::/32;
+    set_real_ip_from 2a06:98c0::/29;
     real_ip_header X-Forwarded-For;
-    set_real_ip_from 172.31.0.0/16;
 
     limit_conn_zone $http_x_forwarded_for zone=addr:100m;
     limit_req_zone $http_x_forwarded_for zone=public:100m rate=20r/s;
@@ -32,7 +53,7 @@ http {
     proxy_buffer_size 8k;
 
     log_format main '$remote_addr - $remote_user [$time_local]  '
-                    '"$request" $status $body_bytes_sent '
+                    '"$request" $status $body_bytes_sent $http_x_forwarded_for '
                     '|"$http_referer"| "$http_user_agent" "$request_time" "$upstream_response_time"';
 
     access_log /dev/stdout main;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -52,8 +52,8 @@ http {
     
     proxy_buffer_size 8k;
 
-    log_format main '$remote_addr - $remote_user [$time_local]  '
-                    '"$request" $status $body_bytes_sent $http_x_forwarded_for '
+    log_format main '$remote_addr - $remote_user X_Forwarded_For: $http_x_forwarded_for [$time_local]  '
+                    '"$request" $status $body_bytes_sent '
                     '|"$http_referer"| "$http_user_agent" "$request_time" "$upstream_response_time"';
 
     access_log /dev/stdout main;


### PR DESCRIPTION
This updates where a `real ip` can come from (in this case cloudflare's ip ranges) and adds `X-Forwarded-For` to standard log output