### PR TITLE
Adjust nginx config for proper rate limiting with CF

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -36,10 +36,10 @@ http {
     set_real_ip_from 2405:8100::/32;
     set_real_ip_from 2c0f:f248::/32;
     set_real_ip_from 2a06:98c0::/29;
-    real_ip_header X-Forwarded-For;
+    real_ip_header CF-Connecting-IP;
 
-    limit_conn_zone $http_x_forwarded_for zone=addr:100m;
-    limit_req_zone $http_x_forwarded_for zone=public:100m rate=20r/s;
+    limit_conn_zone $binary_remote_addr zone=addr:100m;
+    limit_req_zone $binary_remote_addr zone=public:100m rate=20r/s;
 
     limit_conn addr 16;
     limit_req zone=public burst=5;
@@ -52,7 +52,7 @@ http {
     
     proxy_buffer_size 8k;
 
-    log_format main '$remote_addr - $remote_user X_Forwarded_For: $http_x_forwarded_for [$time_local]  '
+    log_format main '$remote_addr - $remote_user CF-Connecting-IP: $http_cf_connecting_ip [$time_local]  '
                     '"$request" $status $body_bytes_sent '
                     '|"$http_referer"| "$http_user_agent" "$request_time" "$upstream_response_time"';
 

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -38,8 +38,8 @@ http {
     set_real_ip_from 2a06:98c0::/29;
     real_ip_header CF-Connecting-IP;
 
-    limit_conn_zone $binary_remote_addr zone=addr:100m;
-    limit_req_zone $binary_remote_addr zone=public:100m rate=20r/s;
+    limit_conn_zone $http_cf_connecting_ip zone=addr:100m;
+    limit_req_zone $http_cf_connecting_ip zone=public:100m rate=20r/s;
 
     limit_conn addr 32;
     limit_req zone=public burst=5;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -36,10 +36,11 @@ http {
     set_real_ip_from 2405:8100::/32;
     set_real_ip_from 2c0f:f248::/32;
     set_real_ip_from 2a06:98c0::/29;
+    set_real_ip_from 172.31.0.0/16;
     real_ip_header CF-Connecting-IP;
 
-    limit_conn_zone $http_cf_connecting_ip zone=addr:100m;
-    limit_req_zone $http_cf_connecting_ip zone=public:100m rate=20r/s;
+    limit_conn_zone $binary_remote_addr zone=addr:100m;
+    limit_req_zone $binary_remote_addr zone=public:100m rate=20r/s;
 
     limit_conn addr 32;
     limit_req zone=public burst=5;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -41,7 +41,7 @@ http {
     limit_conn_zone $binary_remote_addr zone=addr:100m;
     limit_req_zone $binary_remote_addr zone=public:100m rate=20r/s;
 
-    limit_conn addr 16;
+    limit_conn addr 32;
     limit_req zone=public burst=5;
     limit_conn_log_level error;
     limit_req_log_level error;

--- a/site.conf.template
+++ b/site.conf.template
@@ -1,4 +1,4 @@
-limit_req_zone $http_x_forwarded_for zone=sdc:32m rate=100r/m;
+limit_req_zone $binary_remote_addr zone=sdc:32m rate=100r/m;
 proxy_cache_path /var/cache/nginx levels=1:2 inactive=6h keys_zone=sdc_cache:100m;
 
 server {

--- a/site.devstage.conf.template
+++ b/site.devstage.conf.template
@@ -1,4 +1,4 @@
-limit_req_zone $http_x_forwarded_for zone=sdc:32m rate=100r/m;
+limit_req_zone $binary_remote_addr zone=sdc:32m rate=100r/m;
 proxy_cache_path /var/cache/nginx levels=1:2 inactive=6h keys_zone=sdc_cache:100m;
 
 server {

--- a/site.social.conf.template
+++ b/site.social.conf.template
@@ -1,4 +1,4 @@
-limit_req_zone $http_x_forwarded_for zone=sdc:32m rate=100r/m;
+limit_req_zone $binary_remote_addr zone=sdc:32m rate=100r/m;
 proxy_cache_path /var/cache/nginx levels=1:2 inactive=6h keys_zone=sdc_cache:100m;
 
 server {

--- a/site.social.devstage.conf.template
+++ b/site.social.devstage.conf.template
@@ -1,4 +1,4 @@
-limit_req_zone $http_x_forwarded_for zone=sdc:32m rate=100r/m;
+limit_req_zone $binary_remote_addr zone=sdc:32m rate=100r/m;
 proxy_cache_path /var/cache/nginx levels=1:2 inactive=6h keys_zone=sdc_cache:100m;
 
 server {


### PR DESCRIPTION
It's important to keep in mind that these settings apply **per instance** and not sitewide. So while these limits may seem low, they are multiplied by the number of instances currently in service as there is an nginx in front of each condenser.

Things that this PR does:

- Adds back the CIDR that our ALB will be in so it will be trusted as a source that can be used to set a real ip using the real ip module from the cloudflare header.
- Switches to use Cloudflare's custom HTTP header for the source of the IP instead of the standard XFF. The reason for this is that with multiple hops before a request reaches the backend, multiple IP's are appended to the XFF header. This problem can technically be solved by using the 'recursive' setting with the real ip module, but, it is a little less messy doing it this way.
- Uses `$binary_remote_addr` instead of `$http_x_forwarded_for` or `$http_cf_connecting_ip` for connection and rate limiting. This is less overheard and ram usage because it isn't constantly doing string compares. The `$binary_remote_addr` is indeed set properly by the real ip module.
- **Increases** the number of allowed connections per IP from 16 to 32. With CGNAT becoming more and more common, it is much more likely that we'll have many more legitimate connections from the same IP. (Example: one of our biggest sources of traffic right now is Verizon Wireless).
- Leaves existing rate limits in place,  but with the other changes in this PR they will now actually be honored. These can/should be tuned further over time.